### PR TITLE
Add pretty-printing options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ var json2toml = require('json2toml');
 
 json2toml({simple: true});
 // => 'simple = true\n'
+
+// Also supports pretty-printing options
+
+console.log(json2toml({deeply: {option: false, nested: {option: true}}},
+  {indent: 2, newlineAfterSection: true}));
+//[deeply]
+//  option = false
+//
+//[deeply.nested]
+//  option = true
 ```
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -11,10 +11,12 @@ function format(obj) {
     : JSON.stringify(obj);
 }
 
-module.exports = function(hash) {
+module.exports = function(hash, options={}) {
   function visit(hash, prefix) {
     var nestedPairs = [];
     var simplePairs = [];
+
+    var indentStr = "";
 
     forEach(keys(hash).sort(), function(key) {
       var value = hash[key];
@@ -23,14 +25,19 @@ module.exports = function(hash) {
 
     if (!(isEmpty(prefix) || isEmpty(simplePairs))) {
       toml += '[' + prefix + ']\n';
+      indentStr = "".padStart(options.indent, " ");
     }
 
     forEach(simplePairs, function(array) {
       var key = array[0];
       var value = array[1];
 
-      toml += key + ' = ' + format(value) + '\n';
+      toml += indentStr + key + ' = ' + format(value) + '\n';
     });
+
+    if (!isEmpty(simplePairs) && options.newlineAfterSection) {
+      toml += '\n';
+    }
 
     forEach(nestedPairs, function(array) {
       var key = array[0];

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ function format(obj) {
     : JSON.stringify(obj);
 }
 
-module.exports = function(hash, options={}) {
+module.exports = function(hash, options = {}) {
   function visit(hash, prefix) {
     var nestedPairs = [];
     var simplePairs = [];
 
-    var indentStr = "";
+    var indentStr = '';
 
     forEach(keys(hash).sort(), function(key) {
       var value = hash[key];
@@ -25,7 +25,7 @@ module.exports = function(hash, options={}) {
 
     if (!(isEmpty(prefix) || isEmpty(simplePairs))) {
       toml += '[' + prefix + ']\n';
-      indentStr = "".padStart(options.indent, " ");
+      indentStr = ''.padStart(options.indent, ' ');
     }
 
     forEach(simplePairs, function(array) {

--- a/test/index.js
+++ b/test/index.js
@@ -49,3 +49,12 @@ test('nested', function(t) {
              + 'again = "it never ends"\n';
   t.equal(json2toml(hash), toml);
 });
+
+test('pretty', function(t) {
+  t.plan(1);
+
+  var hash = { nested: { hash: { deep: true } } };
+  var toml = '[nested.hash]\n  deep = true\n\n'
+
+  t.equal(json2toml(hash, {indent: 2, newlineAfterSection: true}), toml);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -54,7 +54,7 @@ test('pretty', function(t) {
   t.plan(1);
 
   var hash = { nested: { hash: { deep: true } } };
-  var toml = '[nested.hash]\n  deep = true'
+  var toml = '[nested.hash]\n  deep = true';
 
-  t.equal(json2toml(hash, {indent: 2, newlineAfterSection: true}).trim(), toml);
+  t.equal(json2toml(hash, { indent: 2, newlineAfterSection: true }).trim(), toml);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -54,7 +54,7 @@ test('pretty', function(t) {
   t.plan(1);
 
   var hash = { nested: { hash: { deep: true } } };
-  var toml = '[nested.hash]\n  deep = true\n\n'
+  var toml = '[nested.hash]\n  deep = true'
 
-  t.equal(json2toml(hash, {indent: 2, newlineAfterSection: true}), toml);
+  t.equal(json2toml(hash, {indent: 2, newlineAfterSection: true}).trim(), toml);
 });


### PR DESCRIPTION
Most TOML libraries for JS include only simple stringify function that doesn't try to make the output easily readable for humans.
I've made a few hacks for your lib to allow basic pretty-printing.

I kept the API backwards compatible and added two new optional arguments:
* `indent=<int>`: number of spaces
* `newline_after_section`: outputs a newline after the last pair in a hash if that hash wasn't empty

Example:

```
> console.log(
  json2toml(
    {settings: {work_miracles: true, do_what_i_mean: true}, options: {dwim: {guess_real_intent: true, never_ask: false}}},
    indent=4,
    newline_after_section=true));
[options.dwim]
    guess_real_intent = true
    never_ask = false

[settings]
    do_what_i_mean = true
    work_miracles = true

```