### PR TITLE
feat: remove support for Node.js v6 and v8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [6, 8, 10, 12, 14]
+        node-version: [10, 12, 14]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2.3.1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "6 || 8 || 10 || 12 || >=14"
+    "node": "10 || 12 || >=14"
   },
   "scripts": {
     "test": "tape test/index.js"


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is now the minimum supported version of
Node.js.