### PR TITLE
FIX : https://github.com/KenanY/json2toml/issues/92

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,22 @@ function format(obj) {
     : JSON.stringify(obj);
 }
 
+function isArrayOfTables(simplePairs) {
+  return simplePairs.some(function(array) {
+    var value = array[1];
+    return Array.isArray(value) && isPlainObject(value[0]);
+  });
+}
+
+function isObjectArrayOfTables(obj) {
+  return Array.isArray(obj) && obj.length === 2 && isPlainObject(obj[1][0]);
+}
+
+function isLastObjectArrayOfTables(simplePairs) {
+  var array = simplePairs[simplePairs.length - 1];
+  return isObjectArrayOfTables(array);
+}
+
 module.exports = function(hash, options = {}) {
   function visit(hash, prefix) {
     var nestedPairs = [];
@@ -23,7 +39,8 @@ module.exports = function(hash, options = {}) {
       (isPlainObject(value) ? nestedPairs : simplePairs).push([key, value]);
     });
 
-    if (!(isEmpty(prefix) || isEmpty(simplePairs))) {
+    if (!isEmpty(prefix) && !isEmpty(simplePairs)
+      && !isArrayOfTables(simplePairs)) {
       toml += '[' + prefix + ']\n';
       indentStr = ''.padStart(options.indent, ' ');
     }
@@ -32,10 +49,30 @@ module.exports = function(hash, options = {}) {
       var key = array[0];
       var value = array[1];
 
-      toml += indentStr + key + ' = ' + format(value) + '\n';
+      if (isObjectArrayOfTables(array)) {
+        if (simplePairs.indexOf(array) > 0 && options.newlineAfterSection) {
+          var lastObj = simplePairs[simplePairs.indexOf(array) - 1];
+          if (!isObjectArrayOfTables(lastObj)) {
+            toml += '\n';
+          }
+        }
+        forEach(value, function(obj) {
+          if (!isEmpty(prefix)) {
+            toml += '[[' + prefix + '.' + key + ']]\n';
+          }
+          else {
+            toml += '[[' + key + ']]\n';
+          }
+          visit(obj, '');
+        });
+      }
+      else {
+        toml += indentStr + key + ' = ' + format(value) + '\n';
+      }
     });
 
-    if (!isEmpty(simplePairs) && options.newlineAfterSection) {
+    if (!isEmpty(simplePairs) && !isLastObjectArrayOfTables(simplePairs)
+      && options.newlineAfterSection) {
       toml += '\n';
     }
 

--- a/index.js
+++ b/index.js
@@ -12,14 +12,19 @@ function format(obj) {
 }
 
 function isArrayOfTables(simplePairs) {
-  return simplePairs.some(function(array) {
-    var value = array[1];
-    return Array.isArray(value) && isPlainObject(value[0]);
+  return simplePairs.some(function(simplePairArray) {
+    return Array.isArray(simplePairArray[1]) && isPlainObject(simplePairArray[1][0]);
+  });
+}
+
+function isArrayOfObjects(array) {
+  return Array.isArray(array) && array.every(function(element) {
+    return isPlainObject(element);
   });
 }
 
 function isObjectArrayOfTables(obj) {
-  return Array.isArray(obj) && obj.length === 2 && isPlainObject(obj[1][0]);
+  return Array.isArray(obj) && obj.length === 2 && isArrayOfObjects(obj[1]);
 }
 
 function isLastObjectArrayOfTables(simplePairs) {

--- a/test/index.js
+++ b/test/index.js
@@ -50,6 +50,15 @@ test('nested', function(t) {
   t.equal(json2toml(hash), toml);
 });
 
+test('mixed array', function(t) {
+  t.plan(1);
+  console.log(json2toml({"foo": [{"bar": false}, 9, true]}))
+  var hash = { nested: [{ a: 'one' }, 1, true, 'string'] };
+  var toml = 'nested = [{"a":"one"},1,true,"string"]\n';
+
+  t.equal(json2toml(hash), toml);
+});
+
 test('nested array of tables', function(t) {
   t.plan(2);
 

--- a/test/index.js
+++ b/test/index.js
@@ -50,6 +50,44 @@ test('nested', function(t) {
   t.equal(json2toml(hash), toml);
 });
 
+test('nested array of tables', function(t) {
+  t.plan(2);
+
+  var hash = { nested: [{ a: 'one' }, { a: 'two' }] };
+  var toml = '[[nested]]\n'
+             + 'a = "one"\n'
+             + '[[nested]]\n'
+             + 'a = "two"\n';
+  t.equal(json2toml(hash), toml);
+
+  hash.other = {};
+  hash.other.nest = [{ a: 'one' }, { a: 'two' }];
+  toml = toml + '[[other.nest]]\n'
+          + 'a = "one"\n'
+          + '[[other.nest]]\n'
+          + 'a = "two"\n';
+  t.equal(json2toml(hash), toml);
+});
+
+test('nested array of tables with new line', function(t) {
+  t.plan(2);
+
+  var hash = { nested: [{ a: 'one' }, { a: 'two' }] };
+  var toml = '[[nested]]\n'
+             + 'a = "one"\n\n'
+             + '[[nested]]\n'
+             + 'a = "two"\n\n';
+  t.equal(json2toml(hash, { newlineAfterSection: true }), toml);
+
+  hash.other = {};
+  hash.other.nest = [{ a: 'one' }, { a: 'two' }];
+  toml = toml + '[[other.nest]]\n'
+          + 'a = "one"\n\n'
+          + '[[other.nest]]\n'
+          + 'a = "two"\n\n';
+  t.equal(json2toml(hash, { newlineAfterSection: true }), toml);
+});
+
 test('pretty', function(t) {
   t.plan(1);
 


### PR DESCRIPTION
There is no specification for mixed array in toml. So when array is mixed, it behaves like before. If array is array of objects then it follows the spec to have the array of objects