### PR TITLE
fix(indent): indent on arrays of objects – closes #159

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,7 @@ module.exports = function(hash, options = {}) {
   function visit(hash, prefix) {
     const nestedPairs = [];
     const simplePairs = [];
-
-    let indentStr = '';
+    const indentStr = ''.padStart(options.indent, ' ');
 
     Object.keys(hash).sort().forEach((key) => {
       const value = hash[key];
@@ -78,7 +77,6 @@ module.exports = function(hash, options = {}) {
     if (!isEmpty(prefix) && !isEmpty(simplePairs)
       && !isArrayOfTables(simplePairs)) {
       toml += '[' + prefix + ']\n';
-      indentStr = ''.padStart(options.indent, ' ');
     }
 
     simplePairs.forEach((array) => {


### PR DESCRIPTION
I made a small adjustment to fix the issue I opened (#159).

This shouldn't cause any side effects unless setting `indentStr` inside of the if statement was needed. I don't understand the logic enough to know if that was important, but the tests all passed.