### PR TITLE
feat!: drop support for Node.js v18 and v20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [22, 24]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "18 || >=20"
+    "node": "22 || >=24"
   },
   "scripts": {
     "clean": "rimraf --glob test/**/*.d.ts *.d.ts || true",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v18 and v20 are no longer supported.